### PR TITLE
Migrate to ballerina 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Annotation based build extension implementation for ballerina.
 ## Features:
 - Generate text file with the greetings 
 
+## Compatibility
+|                     |    Version     |
+|:-------------------:|:--------------:|
+| Ballerina Language  | 1.2.x   |
+| JDK | 1.8.x or later          |
 
 ## Supported Annotations:
 
@@ -20,17 +25,11 @@ Annotation based build extension implementation for ballerina.
 
 1. Download and install JDK 8 or later.
 2. Get a clone or download the source from this repository (https://github.com/ballerinax/hello)
-3. Run the Maven command ``mvn clean  install`` from within the hello directory.
-4. Copy ``target/hello-extension-1.0.0.jar`` file to ``<BALLERINA_HOME>/bre/lib`` directory.
-4. Copy contents of ``target/generated-balo/repo`` directory to ``<BALLERINA_HOME>/lib/repo`` directory.
-5. Run ``ballerina build <bal_filename>`` to generate artifacts.
+3. Run the gradle build command ``gradle build`` from within the hello-extension directory.
+4. Copy ``build/libs/hello-extension-1.0-SNAPSHOT.jar`` file to ``<BALLERINA_HOME>/bre/lib`` directory.
+5. Run ``ballerina build greet`` from hello-world to generate the artifacts.
 
-The hello world artifacts will be created in a folder called target with following structure.
-```bash
-target/
-├── outputfilename.txt
-└── outputfilename.balx
-```
+The ``target/greetings/greet.txt`` file should contain the following text: ``Guten Tag! from salutation()``
 
 ### Annotation Usage Sample:
 ```ballerina

--- a/hello-extension/build.gradle
+++ b/hello-extension/build.gradle
@@ -11,8 +11,20 @@ repositories {
     maven {
         url "http://maven.wso2.org/nexus/content/repositories/releases/"
     }
+
+    maven {
+        url = 'https://maven.wso2.org/nexus/content/repositories/snapshots/'
+    }
+
+    maven {
+        url = 'https://maven.wso2.org/nexus/content/groups/wso2-public/'
+    }
+
+    maven {
+        url = 'https://repo.maven.apache.org/maven2'
+    }
 }
 
 dependencies {
-    implementation group: 'org.ballerinalang', name: 'ballerina-lang', version: '1.0.0'
+    implementation group: 'org.ballerinalang', name: 'ballerina-lang', version: '1.2.1'
 }

--- a/hello-extension/src/main/java/xyz/foo/hello/HelloPlugin.java
+++ b/hello-extension/src/main/java/xyz/foo/hello/HelloPlugin.java
@@ -26,9 +26,9 @@ import org.ballerinalang.model.tree.FunctionNode;
 import org.ballerinalang.util.diagnostic.Diagnostic;
 import org.ballerinalang.util.diagnostic.DiagnosticLog;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangRecordKeyValue;
+import org.ballerinalang.model.tree.expressions.RecordLiteralNode.RecordField;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangRecordKeyValueField;
 
 import java.io.File;
 import java.io.IOException;
@@ -67,14 +67,14 @@ public class HelloPlugin extends AbstractCompilerPlugin {
             }
 
             // Retrieve the fields of the annotation value.
-            List<BLangRecordKeyValue> annotFields =
-                    ((BLangRecordLiteral) ((BLangAnnotationAttachment) annotation).expr).getKeyValuePairs();
+            List<RecordField> annotFields = ((BLangRecordLiteral)((BLangAnnotationAttachment) annotation).expr).getFields();
 
             // In this particular case, there is no need to iterate through the list since our annotation only has
             // one field. So let's just take the first element of the fields list.
-            BLangRecordKeyValue salutationField = annotFields.get(0);
-            String annotFieldValue = ((BLangLiteral) salutationField.getValue()).getValue().toString();
-            String greeting = String.format("%s from %s()\n", annotFieldValue, functionNode.getName().getValue());
+            BLangRecordKeyValueField salutationField = (BLangRecordKeyValueField) annotFields.get(0);
+            String annotFieldName = salutationField.key.toString();
+            String annotFieldValue = salutationField.getValue().toString();
+            String greeting = String.format("%s from %s()\n", annotFieldValue, annotFieldName);
             HelloModel.getInstance().setGreeting(greeting);
         }
     }

--- a/hello-world/Ballerina.toml
+++ b/hello-world/Ballerina.toml
@@ -3,4 +3,4 @@ org-name= "bar"
 version= "0.1.0"
 
 [dependencies]
-"foo/hello" = {path = "../hello-annotation/target/balo/hello-2019r3-any-0.1.0.balo"}
+"foo/hello" = {path = "../hello-annotation/target/balo/hello-2020r1-any-0.1.0.balo"}


### PR DESCRIPTION
## Purpose
To migrate hello example code to Ballerina 1.2.1

## Goals
This fix will enable the hello example to use Ballerina 1.2.1. Especially this will remove the dependency on ballerinax modules.

## Approach
Replaced the use of ballerinax modules with their corresponding ballerina modules. Updated the README file with the details of building and running the example.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Test environment
Ballerina 1.2.1, JDK 1.8, Ubuntu 18.04